### PR TITLE
Fixes blink.cmp support's new async module

### DIFF
--- a/lua/css-vars/blink.lua
+++ b/lua/css-vars/blink.lua
@@ -1,5 +1,5 @@
 local Job = require("plenary.job")
-local async = require("blink.lib.async")
+local async = require("blink.lib.task")
 
 local config
 local css_variables

--- a/lua/css-vars/blink.lua
+++ b/lua/css-vars/blink.lua
@@ -1,5 +1,5 @@
 local Job = require("plenary.job")
-local async = require("blink.cmp.lib.async")
+local async = require("blink.lib.async")
 
 local config
 local css_variables

--- a/lua/css-vars/blink.lua
+++ b/lua/css-vars/blink.lua
@@ -90,7 +90,7 @@ end
 
 ---@param context blink.cmp.Context
 function M:get_completions(context, callback)
-	local task = async.task.empty():map(function()
+	local task = async.new(function()
 		local is_char_trigger = vim.list_contains(
 			self:get_trigger_characters(),
 			context.line:sub(context.bounds.start_col - 1, context.bounds.start_col - 1)


### PR DESCRIPTION
blink.cmp extracted their libraries into a separate package and renamed the async package to task. This seems to fix the issue by referring to the new task module. I've tested a little with some open-props css files and it seems to work.